### PR TITLE
Add note for 'no matching key exchange method'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The initramfs image is based on OpenWrt version 23.05.0. If you would like to bu
 
  1. Enable SSH on your ER605 by logging into the web configuration GUI, navigating to System Tools > Diagnostics > Remote Assistance, and enabling Remote Assistance.
  2. Generate your shell password by clicking [here](https://chill1penguin.github.io/er605v2_openwrt_install/er605rootpw.html).
- 3. SSH into your ER605. Use `ssh -o hostkeyalgorithms=ssh-rsa` if your ssh client complains `no matching host key type`. Follow the steps below for the firmware version you have installed:<br>
+ 3. SSH into your ER605. Use `ssh -o hostkeyalgorithms=ssh-rsa` if your ssh client complains `no matching host key type`, and use `-o KexAlgorithms=+diffie-hellman-group1-sha1` if it complains `no matching key exchange method found`. Follow the steps below for the firmware version you have installed:<br>
 ***v2.0.1 and below:*** Login using the username `root` and the "root password" generated in the previous step.<br>
 ***v2.1.1 and above:*** Login using your web configuration GUI credentials. Then run the `enable` command followed by the `debug` command. When you are prompted for a password, enter the "CLI debug mode password" generated in the previous step.
  5. Backup your MTD partitions (recommended). The backup process will not be covered in these instructions. You can find some more information on how to do this here: [https://openwrt.org/docs/guide-user/installation/generic.backup?do=#create_full_mtd_backup](https://openwrt.org/docs/guide-user/installation/generic.backup?do=#create_full_mtd_backup)


### PR DESCRIPTION
Just another note for anyone using recent OpenSSH clients, as they've removed some legacy key exchange algorithms so this is a common issue connecting to older SSH servers.  I couldn't SSH into a brand new ER605v2 without this option.