### PR TITLE
Update README.md for web page warning on step 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ The initramfs image is based on OpenWrt version 23.05.0. If you would like to bu
  ./er605v2_write_initramfs.sh openwrt-initramfs-compact.bin
  ```
  8. Reboot the ER605 and wait for it to reboot.
- 9. Open a web browser and navigate to [http://192.168.1.1/](http://192.168.1.1/). If the page does not load, try waiting a bit longer or clearing your browser cache.
- 10. Follow the steps on the [web page](http://192.168.1.1/). You can find a sysupgrade image at [https://downloads.openwrt.org](https://downloads.openwrt.org). Click [here](https://downloads.openwrt.org/releases/23.05.0/targets/ramips/mt7621/openwrt-23.05.0-ramips-mt7621-tplink_er605-v2-squashfs-sysupgrade.bin) to download the v23.05.0 sysupgrade image.
+ 9. Open a web browser and navigate to [http://192.168.1.1/](http://192.168.1.1/). If the page does not load, try waiting a bit longer or clearing your browser cache. (_Having a WAN connected can cause the router to act as an AP if using DHCP, which can in turn not allow router to get the 192.168.1.1 address. Better to not have any WAN connect to be safe_)
+ 10. Follow the steps on the web page. You can find a sysupgrade image at [https://downloads.openwrt.org](https://downloads.openwrt.org). Click [here](https://downloads.openwrt.org/releases/23.05.0/targets/ramips/mt7621/openwrt-23.05.0-ramips-mt7621-tplink_er605-v2-squashfs-sysupgrade.bin) to download the v23.05.0 sysupgrade image.
  11. After rebooting, your ER605 should boot into OpenWrt! :smile:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ The initramfs image is based on OpenWrt version 23.05.0. If you would like to bu
  ./er605v2_write_initramfs.sh openwrt-initramfs-compact.bin
  ```
  8. Reboot the ER605 and wait for it to reboot.
- 9. Open a web browser and navigate to [http://192.168.1.1/](http://192.168.1.1/). If the page does not load, try waiting a bit longer or clearing your browser cache. (_Having a WAN connected can cause the router to act as an AP if using DHCP, which can in turn not allow router to get the 192.168.1.1 address. Better to not have any WAN connect to be safe_)
+ 9. Open a web browser and navigate to [http://192.168.1.1/](http://192.168.1.1/). If the page does not load, try waiting a bit longer or clearing your browser cache. ( _Having another router or DHCP server connected to the ER605 could cause page load issues due to an IP address conflict. If you cannot access the web page, disconnect all unnecessary devices from the ER605 and try again._)
  10. Follow the steps on the web page. You can find a sysupgrade image at [https://downloads.openwrt.org](https://downloads.openwrt.org). Click [here](https://downloads.openwrt.org/releases/23.05.0/targets/ramips/mt7621/openwrt-23.05.0-ramips-mt7621-tplink_er605-v2-squashfs-sysupgrade.bin) to download the v23.05.0 sysupgrade image.
  11. After rebooting, your ER605 should boot into OpenWrt! :smile:

--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ The initramfs image is based on OpenWrt version 23.05.0. If you would like to bu
  ```
  8. Reboot the ER605 and wait for it to reboot.
  9. Open a web browser and navigate to [http://192.168.1.1/](http://192.168.1.1/). If the page does not load, try waiting a bit longer or clearing your browser cache.
- 10. Follow the steps on the web page. You can find a sysupgrade image at [https://downloads.openwrt.org](https://downloads.openwrt.org). Click [here](https://downloads.openwrt.org/releases/23.05.0/targets/ramips/mt7621/openwrt-23.05.0-ramips-mt7621-tplink_er605-v2-squashfs-sysupgrade.bin) to download the v23.05.0 sysupgrade image.
+ 10. Follow the steps on the [web page](http://192.168.1.1/). You can find a sysupgrade image at [https://downloads.openwrt.org](https://downloads.openwrt.org). Click [here](https://downloads.openwrt.org/releases/23.05.0/targets/ramips/mt7621/openwrt-23.05.0-ramips-mt7621-tplink_er605-v2-squashfs-sysupgrade.bin) to download the v23.05.0 sysupgrade image.
  11. After rebooting, your ER605 should boot into OpenWrt! :smile:


### PR DESCRIPTION
Closes #13 

It was confusing for me.

As I had a WAN connected. Which is coming from another router so my ER605 was acting as an AP(_with address 192.168.2.2 in my case. Gateway was a different device_). Which was in turn stopping IP address assignment of 192.168.1.1.

After disconnecting the WAN and restart, I got the 192.168.1.1 as gateway.